### PR TITLE
fix predict_function in ceteris_paribus

### DIFF
--- a/R/what_if.R
+++ b/R/what_if.R
@@ -45,12 +45,12 @@ ceteris_paribus <- function(explainer, observation, grid_points = 101) {
     quant_x <- mean(observation[1,vname] >= data[,vname], na.rm = TRUE)
     new_data <- observation[rep(1, grid_points),]
     new_data[,vname] <- new_x
-    data.frame(y_hat = predict_function(model, newdata = new_data), new_x = new_x,
+    data.frame(y_hat = predict_function(model, new_data), new_x = new_x,
                vname = vname, x_quant = quant_x, quant = probs,
                relative_quant = probs - quant_x, label = explainer$label)
   })
   all_responses <- do.call(rbind, responses)
-  new_y_hat <- predict_function(model, newdata = observation)
+  new_y_hat <- predict_function(model, observation)
 
   attr(all_responses, "prediction") <- list(observation = observation, new_y_hat = new_y_hat)
   class(all_responses) = c("ceteris_paribus_explainer", "data.frame")


### PR DESCRIPTION
I've fixed the problem for `ceteris_paribus()` with custom predict_function. It was working only when the name of the second parameter of predict_function was 'newdata'.

Code below was returning an error:
Error in predict_function(model, newdata = new_data) : 
  unused argument (newdata = new_data)

```
library(gbm)
library(DALEX)
library(ceterisParibus)

pred_boost<-function(model, data){
  predict(model, newdata=data, n.trees=model$n.trees)
}

gbm <- gbm(m2.price~., data = apartments, n.trees = 2000)
exp_gbm <- explain(gbm, data = apartmentsTest, y = apartmentsTest, predict_function = pred_boost)
cp_gbm <- ceteris_paribus(exp_gbm, observation = apartmentsTest[1,])
```